### PR TITLE
增加代码生成命令 gen

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ func tip() {
 
 func init() {
 	rootCmd.AddCommand(start.StartCmd)
+	rootCmd.AddCommand(start.GenCmd)
 	rootCmd.AddCommand(version.StartCmd)
 }
 

--- a/cmd/start/gen.go
+++ b/cmd/start/gen.go
@@ -1,0 +1,148 @@
+package start
+
+import (
+	"dilu/common/config"
+	cons "dilu/common/consts"
+	"dilu/modules/tools/service"
+	"fmt"
+	"strings"
+	"time"
+
+	coreCfg "github.com/baowk/dilu-core/config"
+
+	"github.com/baowk/dilu-core/core"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	_ "github.com/spf13/viper/remote"
+)
+
+var (
+	dbName    string
+	tableName string
+	force     bool
+	GenCmd    = &cobra.Command{
+		Use:     "gen",
+		Short:   "Generate code",
+		Long:    "Generate code based on database tables",
+		Example: "dilu gen -c resources/config.dev.yml -d sys -t sys_users",
+		Run: func(cmd *cobra.Command, args []string) {
+			gen()
+		},
+	}
+)
+
+func init() {
+	GenCmd.PersistentFlags().StringVarP(&configYml, "config", "c", "resources/config.dev.yml", "Start server with provided configuration file")
+	GenCmd.PersistentFlags().StringVarP(&dbName, "db", "d", "", "database name")
+	GenCmd.PersistentFlags().StringVarP(&tableName, "table", "t", "", "table name")
+	GenCmd.PersistentFlags().BoolVar(&force, "force", false, "if set to true, will overwrite existing files")
+}
+
+func gen() {
+	if configYml == "" {
+		panic("找不到配置文件")
+	}
+	v := viper.New()
+	v.SetConfigFile(configYml)
+	//v.SetConfigType("yaml")
+	err := v.ReadInConfig()
+	if err != nil {
+		panic(fmt.Sprintf("Fatal error config file: %v \n", err))
+	}
+
+	var cfg coreCfg.AppCfg
+
+	if err = v.Unmarshal(&cfg); err != nil {
+		fmt.Println(err)
+	}
+
+	if cfg.Server.RemoteEnable {
+		rviper := viper.New()
+		if cfg.Remote.SecretKeyring == "" {
+			err = rviper.AddRemoteProvider(cfg.Remote.Provider, cfg.Remote.Endpoint, cfg.Remote.Path)
+		} else {
+			err = rviper.AddSecureRemoteProvider(cfg.Remote.Provider, cfg.Remote.Endpoint, cfg.Remote.Path, cfg.Remote.SecretKeyring)
+		}
+		if err != nil {
+			panic(fmt.Sprintf("Fatal error remote config : %v \n", err))
+		}
+		rviper.SetConfigType(cfg.Remote.GetConfigType())
+		err = rviper.ReadRemoteConfig()
+		if err != nil {
+			panic(fmt.Sprintf("Fatal error remote config : %v \n", err))
+		}
+		var remoteCfg coreCfg.AppCfg
+		rviper.Unmarshal(&remoteCfg)
+
+		mergeCfg(&cfg, &remoteCfg)
+
+		extend := rviper.Sub("extend")
+		if extend != nil {
+			extend.Unmarshal(config.Ext)
+		}
+		go func() {
+			for {
+				time.Sleep(time.Second * 5) // delay after each request
+				err := rviper.WatchRemoteConfig()
+				if err != nil {
+					fmt.Println(err)
+					continue
+				}
+				rviper.Unmarshal(&remoteCfg)
+
+				mergeCfg(&cfg, &remoteCfg)
+
+				extend := rviper.Sub("extend")
+				if extend != nil {
+					extend.Unmarshal(config.Ext)
+				}
+			}
+		}()
+	} else {
+		mergeCfg(&cfg, nil)
+		v.Sub("extend").Unmarshal(&config.Ext)
+		v.WatchConfig()
+		v.OnConfigChange(func(e fsnotify.Event) {
+			fmt.Println("config file changed:", e.String())
+			if err = v.Unmarshal(cfg); err != nil {
+				fmt.Println(err)
+			}
+			mergeCfg(&cfg, nil)
+			extend := v.Sub("extend")
+			if extend != nil {
+				extend.Unmarshal(config.Ext)
+			}
+		})
+	}
+
+	core.Init()
+
+	// 生成
+	fmt.Printf("db %s table %s", dbName, tableName)
+	tab, err := service.SerGenTables.GenTableInit(dbName, tableName)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	tab.ApiRoot = cons.ApiRoot
+
+	for i, v := range tab.Columns {
+		tab.Columns[i].TsType = TypeGo2Ts(v.GoType)
+	}
+	service.SerGenTables.NOMethodsGen(tab, force)
+}
+
+func TypeGo2Ts(t string) string {
+	if strings.Contains(t, "int") {
+		return "number"
+	} else if strings.Contains(t, "time") {
+		return "Date"
+	} else if strings.Contains(t, "bool") {
+		return "boolean"
+	} else {
+		return t
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module dilu
 go 1.20
 
 require (
-	github.com/baowk/dilu-core v0.2.8
+	github.com/baowk/dilu-core v0.2.9
 	github.com/baowk/dilu-plugin v0.0.0-20231229162418-ede128faad8f
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
```txt
Generate code based on database tables

Usage:
  dilu gen [flags]

Examples:
dilu gen -c resources/config.dev.yml -d sys -t sys_users

Flags:
  -c, --config string   Start server with provided configuration file (default "resources/config.dev.yml")
  -d, --db string       database name
      --force           if set to true, will overwrite existing files
  -h, --help            help for gen
  -t, --table string    table name
```